### PR TITLE
don't build with advance toolchain on ppc64 ppc64le

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -199,13 +199,6 @@ if sysname == 'freebsd' or sysname == 'sunos':
     env.Append(CPPFLAGS = ' -I/usr/local/include ')
 if sysname == 'sunos':
     env.Replace(SHLINKFLAGS = '-shared ')
-if sysname == 'linux' and (machine == 'ppc64' or machine == 'ppc64le'):
-    # Special case for P8 RHEL 6.5
-    if (platform.linux_distribution()[0] == 'Red Hat Enterprise Linux Server' and
-        platform.linux_distribution()[1] == '6.5'):
-        env.Append(LIBPATH = ['/opt/at7.0/lib64/'])
-    else:
-        env.Append(LIBPATH = ['/opt/at8.0/lib64/'])
 
 # Add paths is extra_sysroot argument was specified
 extra_sysroot = ARGUMENTS.get('extra_sysroot', '')

--- a/scripts/packages/galera.spec
+++ b/scripts/packages/galera.spec
@@ -91,22 +91,6 @@ BuildRequires: systemd
 %define systemd 0
 %endif
 
-%ifarch ppc64le 
-%if 0%{?rhel} >= 7
-Requires: advance-toolchain-at8.0-runtime
-%endif
-AutoReq: 0
-%endif
-
-%ifarch ppc64
-%if 0%{?rhel} >= 7
-Requires: advance-toolchain-at8.0-runtime
-%else 
-Requires: advance-toolchain-at7.0-runtime
-%endif
-AutoReq: 0
-%endif
-
 Requires:      openssl
 
 Provides:      wsrep, %{name} = %{version}-%{release}


### PR DESCRIPTION
We now have ppc64 and ppc6le builders that do not have the advance toolchain and we don't need our galera packages to be built with the advance toolchain or have a dependency on the advance-toolchain-runtime package.