### PR TITLE
MDEV-17565: Sporadic Galera failures when testing MariaDB with mtr

### DIFF
--- a/galera/src/certification.cpp
+++ b/galera/src/certification.cpp
@@ -808,7 +808,7 @@ galera::Certification::do_test_preordered(TrxHandle* trx)
 }
 
 
-galera::Certification::Certification(gu::Config& conf, ServiceThd& thd)
+galera::Certification::Certification(gu::Config& conf, ServiceThd& thd, gcache::GCache& gcache)
     :
     version_               (-1),
     trx_map_               (),
@@ -816,6 +816,7 @@ galera::Certification::Certification(gu::Config& conf, ServiceThd& thd)
     cert_index_ng_         (),
     deps_set_              (),
     service_thd_           (thd),
+    gcache_                (gcache),
     mutex_                 (),
     trx_size_warn_count_   (0),
     initial_position_      (-1),
@@ -1066,7 +1067,7 @@ wsrep_seqno_t galera::Certification::set_trx_committed(TrxHandle* trx)
             deps_set_.erase(i);
         }
 
-        if (gu_unlikely(index_purge_required()))
+        if (gu_unlikely(gcache_.cleanup_required() || index_purge_required()))
         {
             ret = get_safe_to_discard_seqno_();
         }

--- a/galera/src/certification.hpp
+++ b/galera/src/certification.hpp
@@ -48,7 +48,7 @@ namespace galera
             TEST_FAILED
         } TestResult;
 
-        Certification(gu::Config& conf, ServiceThd& thd);
+        Certification(gu::Config& conf, ServiceThd& thd, gcache::GCache& gcache);
         ~Certification();
 
         void assign_initial_position(wsrep_seqno_t seqno, int versiono);
@@ -183,6 +183,7 @@ namespace galera
         CertIndexNG   cert_index_ng_;
         DepsSet       deps_set_;
         ServiceThd&   service_thd_;
+        gcache::GCache& gcache_;
         gu::Mutex     mutex_;
         size_t        trx_size_warn_count_;
         wsrep_seqno_t initial_position_;

--- a/galera/src/galera_gcs.hpp
+++ b/galera/src/galera_gcs.hpp
@@ -43,7 +43,8 @@ namespace galera
         virtual ssize_t replv(const WriteSetVector&,
                               gcs_action& act, bool) = 0;
         virtual ssize_t repl (gcs_action& act, bool) = 0;
-        virtual gcs_seqno_t caused() = 0;
+        virtual void    caused(gcs_seqno_t& seqno,
+                               gu::datetime::Date& wait_until) = 0;
         virtual ssize_t schedule() = 0;
         virtual ssize_t interrupt(ssize_t) = 0;
         virtual ssize_t resume_recv() = 0;
@@ -141,7 +142,23 @@ namespace galera
             return gcs_repl(conn_, &act, scheduled);
         }
 
-        gcs_seqno_t caused() { return gcs_caused(conn_);   }
+        void caused(gcs_seqno_t& seqno, gu::datetime::Date& wait_until)
+        {
+            long err;
+
+            while ((err = gcs_caused(conn_, seqno)) == -EAGAIN &&
+                   gu::datetime::Date::calendar() < wait_until)
+            {
+                usleep(1000);
+            }
+
+            if (err == -EAGAIN) err = -ETIMEDOUT;
+
+            if (err < 0)
+            {
+                gu_throw_error(-err);
+            }
+        }
 
         ssize_t schedule()   { return gcs_schedule(conn_); }
 
@@ -233,6 +250,11 @@ namespace galera
 
         size_t  max_action_size() const { return GCS_MAX_ACT_SIZE; }
 
+        void join_notification()
+        {
+            gcs_join_notification(conn_);
+        }
+
     private:
 
         Gcs(const Gcs&);
@@ -311,7 +333,10 @@ namespace galera
             return ret;
         }
 
-        gcs_seqno_t caused() { return global_seqno_; }
+        void caused(gcs_seqno_t& seqno, gu::datetime::Date& wait_until)
+        {
+            seqno = global_seqno_;
+        }
 
         ssize_t schedule()
         {

--- a/galera/src/replicator_str.cpp
+++ b/galera/src/replicator_str.cpp
@@ -536,7 +536,9 @@ ReplicatorSMM::prepare_state_request (const void* const   sst_req,
             }
             catch (gu::Exception& e)
             {
-                log_warn
+                log_info << "State gap can't be serviced using IST."
+                            " Switching to SST";
+                log_info
                     << "Failed to prepare for incremental state transfer: "
                     << e.what() << ". IST will be unavailable.";
             }

--- a/galera/tests/write_set_check.cpp
+++ b/galera/tests/write_set_check.cpp
@@ -51,6 +51,7 @@ namespace
 
         gu::Config&         conf() { return conf_; }
         galera::ServiceThd& thd()  { return thd_;  }
+        gcache::GCache&     gcache() { return gcache_; }
 
     private:
 
@@ -408,7 +409,7 @@ START_TEST(test_cert_hierarchical_v1)
     size_t nws(sizeof(wsi)/sizeof(wsi[0]));
 
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
     int const version(1);
     cert.assign_initial_position(0, version);
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
@@ -530,7 +531,7 @@ START_TEST(test_cert_hierarchical_v2)
     size_t nws(sizeof(wsi)/sizeof(wsi[0]));
 
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
 
     cert.assign_initial_position(0, version);
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
@@ -580,7 +581,8 @@ START_TEST(test_trac_726)
 
     const int version(2);
     TestEnv env;
-    galera::Certification cert(env.conf(), env.thd());
+    galera::Certification cert(env.conf(), env.thd(), env.gcache());
+
     galera::TrxHandle::Params const trx_params("", version,KeySet::MAX_VERSION);
     wsrep_uuid_t uuid1 = {{1, }};
     wsrep_uuid_t uuid2 = {{2, }};

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -99,6 +99,14 @@ namespace gcache
                                    int64_t& seqno_d,
                                    ssize_t& size);
 
+        /*!
+         * Implements the cleanup policy test.
+         */
+        bool cleanup_required()
+        {
+            return (params.keep_pages_size() && ps.total_size() > params.keep_pages_size());
+        }
+
         class Buffer
         {
         public:

--- a/gcs/src/SConscript
+++ b/gcs/src/SConscript
@@ -7,6 +7,7 @@ libgcs_env = env.Clone()
 
 # Include paths
 libgcs_env.Append(CPPPATH = Split('''
+                                     #/common
                                      #/galerautils/src
                                      #/gcomm/src
                                      #/gcache/src
@@ -15,18 +16,18 @@ libgcs_env.Append(CPPPATH = Split('''
 # Backends (TODO: Get from global options)
 libgcs_env.Append(CPPFLAGS = ' -DGCS_USE_GCOMM')
 # For C-style logging
-libgcs_env.Append(CPPFLAGS = ' -DGALERA_LOG_H_ENABLE_CXX -Wno-variadic-macros')
+libgcs_env.Append(CPPFLAGS = ' -DGALERA_LOG_H_ENABLE_CXX')
 # Disable old style cast warns until code is fixed
-libgcs_env.Append(CPPFLAGS = ' -Wno-old-style-cast')
+libgcs_env.Replace(CXXFLAGS = libgcs_env['CXXFLAGS'].replace('-Wold-style-cast', ''))
+libgcs_env.Replace(CXXFLAGS = libgcs_env['CXXFLAGS'].replace('-Weffc++', ''))
 # Allow zero sized arrays
 libgcs_env.Replace(CCFLAGS = libgcs_env['CCFLAGS'].replace('-pedantic', ''))
-libgcs_env.Append(CPPFLAGS = ' -Wno-missing-field-initializers')
-libgcs_env.Append(CPPFLAGS = ' -Wno-effc++')
+libgcs_env.Append(CCFLAGS = ' -Wno-missing-field-initializers')
+libgcs_env.Append(CCFLAGS = ' -Wno-variadic-macros')
 
-print libgcs_env['CFLAGS']
-print libgcs_env['CCFLAGS']
-print libgcs_env['CPPFLAGS']
-print libgcs_env['CXXFLAGS']
+print('gcs flags:')
+for f in ['CFLAGS', 'CXXFLAGS', 'CCFLAGS', 'CPPFLAGS']:
+    print(f + ': ' + libgcs_env[f].strip())
 
 gcs4garb_env = libgcs_env.Clone()
 

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -175,6 +175,10 @@ struct gcs_conn
     /* #603, #606 join control */
     bool        volatile need_to_join;
     gcs_seqno_t volatile join_seqno;
+    void        join_notification()
+    {
+        need_to_join = true;
+    }
 
     /* sync control */
     bool         sync_sent_;
@@ -880,17 +884,14 @@ _join (gcs_conn_t* conn, gcs_seqno_t seqno)
     while (-EAGAIN == (err = gcs_core_send_join (conn->core, seqno)))
         usleep (10000);
 
-    switch (err)
+    if (gu_unlikely(err < 0))
     {
-    case -ENOTCONN:
         gu_warn ("Sending JOIN failed: %d (%s). "
                  "Will retry in new primary component.", err, strerror(-err));
-    case 0:
-        return 0;
-    default:
-        gu_error ("Sending JOIN failed: %d (%s).", err, strerror(-err));
         return err;
     }
+
+    return 0;
 }
 
 /*! Handles configuration action */
@@ -1035,8 +1036,8 @@ gcs_handle_act_state_req (gcs_conn_t*          conn,
 
 /*! Allocates buffer with malloc to pass to the upper layer. */
 static long
-gcs_handle_state_change (gcs_conn_t*           conn,
-                         const struct gcs_act* act)
+gcs_handle_state_change (gcs_conn_t*     conn,
+                         struct gcs_act* act)
 {
     gu_debug ("Got '%s' dated %lld", gcs_act_type_to_str (act->type),
               gcs_seqno_gtoh(*(gcs_seqno_t*)act->buf));
@@ -1378,14 +1379,11 @@ static void *gcs_recv_thread (void *arg)
         }
         else if (conn->my_idx == rcvd.sender_idx)
         {
-            gu_fatal("Protocol violation: unordered local action not in repl_q:"
-                     " { {%p, %zd, %s}, %ld, %lld }.",
+            gu_debug("Discarding: unordered local action not in repl_q: "
+                     "{ {%p, %zd, %s}, %ld, %lld }.",
                      rcvd.act.buf, rcvd.act.buf_len,
                      gcs_act_type_to_str(rcvd.act.type), rcvd.sender_idx,
                      rcvd.id);
-            assert(0);
-            ret = -ENOTRECOVERABLE;
-            break;
         }
         else
         {
@@ -1405,9 +1403,12 @@ static void *gcs_recv_thread (void *arg)
     }
     else if (ret < 0)
     {
+        /* We must set connection state to 'closed' to avoid the race
+           condition between gcs_recv_thread() and gcs_recv(), which
+           could lead to assertion in gcs_recv: */
+        gcs_shift_state (conn, GCS_CONN_CLOSED);
         /* In case of error call _close() to release repl_q waiters. */
         (void)_close(conn, false);
-        gcs_shift_state (conn, GCS_CONN_CLOSED);
     }
     gu_info ("RECV thread exiting %d: %s", ret, strerror(-ret));
     return NULL;
@@ -1597,9 +1598,9 @@ long gcs_interrupt (gcs_conn_t* conn, long handle)
     return gcs_sm_interrupt (conn->sm, handle);
 }
 
-gcs_seqno_t gcs_caused(gcs_conn_t* conn)
+long gcs_caused(gcs_conn_t* conn, gcs_seqno_t& seqno)
 {
-    return gcs_core_caused(conn->core);
+    return gcs_core_caused(conn->core, seqno);
 }
 
 /* Puts action in the send queue and returns after it is replicated */
@@ -1998,10 +1999,29 @@ gcs_set_last_applied (gcs_conn_t* conn, gcs_seqno_t seqno)
 long
 gcs_join (gcs_conn_t* conn, gcs_seqno_t seqno)
 {
-    conn->join_seqno   = seqno;
-    conn->need_to_join = true;
+    // Even when node is evicted from the cluster in middle of SST,
+    // the SST may completes normally. After this, the node calls
+    // the gcs_join function and tries to join the cluster. However,
+    // this is impossible, because the node is already evicted.
+    // Therefore, the _join() function (which called from gcs_join)
+    // fails. Then node does IST (which also fails), after/during
+    // which it is aborted. To fix this, we should avoid joining
+    // the cluster through gcs_join function if node is evicted.
+    // To do this, we should check the current connection state
+    // in the gcs_join() function to return from it immediately
+    // if the node's communication channel was closed:
 
-    return _join (conn, seqno);
+    if (conn->state < GCS_CONN_CLOSED)
+    {
+        conn->join_seqno   = seqno;
+        conn->need_to_join = true;
+
+        return _join (conn, seqno);
+    }
+    else
+    {
+        return GCS_CLOSED_ERROR;
+    }
 }
 
 gcs_seqno_t gcs_local_sequence(gcs_conn_t* conn)
@@ -2294,4 +2314,9 @@ const char* gcs_param_get (gcs_conn_t* conn, const char* key)
     gu_warn ("Not implemented: %s", __FUNCTION__);
 
     return NULL;
+}
+
+void gcs_join_notification(gcs_conn_t* conn)
+{
+     conn->need_to_join = true;
 }

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -280,9 +280,11 @@ extern long gcs_resume_recv (gcs_conn_t* conn);
  * After action with this seqno is applied, this thread is guaranteed to see
  * all the changes made by the client, even on other nodes.
  *
- * @return global sequence number or negative error code
+ * @retval 0       success
+ * @retval -EPERM  operation not permitted (in NON_PRIMARY state)
+ * @retval -EAGAIN operation may be retried later (in transient state)
  */
-extern gcs_seqno_t gcs_caused(gcs_conn_t* conn);
+extern long gcs_caused (gcs_conn_t* conn, gcs_seqno_t& seqno);
 
 /*! @brief Sends state transfer request
  * Broadcasts state transfer request which will be passed to one of the
@@ -450,6 +452,8 @@ extern void gcs_get_stats (gcs_conn_t *conn, struct gcs_stats* stats);
 extern void gcs_flush_stats(gcs_conn_t *conn);
 
 void gcs_get_status(gcs_conn_t* conn, gu::Status& status);
+
+extern void gcs_join_notification(gcs_conn_t *conn);
 
 /*! A node with this name will be treated as a stateless arbitrator */
 #define GCS_ARBITRATOR_NAME "garb"

--- a/gcs/src/gcs_core.hpp
+++ b/gcs/src/gcs_core.hpp
@@ -154,8 +154,8 @@ gcs_core_send_sync (gcs_core_t* core, gcs_seqno_t seqno);
 extern long
 gcs_core_send_fc (gcs_core_t* core, const void* fc, size_t fc_size);
 
-extern gcs_seqno_t
-gcs_core_caused(gcs_core_t* core);
+extern long
+gcs_core_caused (gcs_core_t* core, gcs_seqno_t& seqno);
 
 extern long
 gcs_core_param_set (gcs_core_t* core, const char* key, const char* value);

--- a/gcs/src/gcs_node.cpp
+++ b/gcs/src/gcs_node.cpp
@@ -181,6 +181,7 @@ gcs_node_update_status (gcs_node_t* node, const gcs_state_quorum_t* quorum)
             else {
                 node->desync_count = 1;
             }
+            // fall through
         case GCS_NODE_STATE_SYNCED:
             node->count_last_applied = true;
             break;

--- a/gcs/src/gcs_test.cpp
+++ b/gcs/src/gcs_test.cpp
@@ -644,15 +644,19 @@ static long gcs_test_conf (gcs_test_conf_t *conf, long argc, char *argv[])
     case 6:
         conf->n_recv = strtol (argv[5], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fall through
     case 5:
         conf->n_send = strtol (argv[4], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fall through
     case 4:
         conf->n_repl = strtol (argv[3], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fall through
     case 3:
         conf->n_tries = strtol (argv[2], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fall through
     case 2:
         conf->backend = argv[1];
         break;

--- a/gcs/src/unit_tests/SConscript
+++ b/gcs/src/unit_tests/SConscript
@@ -5,6 +5,7 @@ env = check_env.Clone()
 
 # Include paths
 env.Append(CPPPATH = Split('''
+                              #/common
                               #/galerautils/src
                               #/gcache/src
                               #/gcs/src


### PR DESCRIPTION
This patch fixes several bugs in Galera that lead to sporadic
failures when testing MariaDB server with the mtr due to false
error messages (or warnings) that are not related to the new
fixes.

The patch includes a some changes taken from the latest
versions of Galera from Codership, as well as some changes
taken from PXC version of Galera, as well as some corrections
made by me.

1) Some mtr tests sometimes fails due to
"[Warning] WSREP: gcs_caused() returned -1" warnings:

Currently gcs_.caused() function works only when the group
is primary, and fails if the group is non-primary or even if
the group in a transient state (during configuration changes).

Instead of failing immediately, this patch changes gcs_.caused()
to return EAGAIN error code when function was called while
group in a transient state. On receiving EAGAIN error code
ReplicatorSMM::causal_read() retries to obtain a new seqno
(by calling gcs_.caused() again).

2) Some mtr tests sometimes fails due to
"[Warning] WSREP: Failed to report last committed <number>"
warnings:

This is because when processing cluster configuration changes,
the GCS layer does not always timely update the group->last_applied
variable.

To correct this error, I added an additional call to the
group_redo_last_applied() function. In addition, to protect
against other similar situations, I added a cycle to re-call
gcs_.set_last_applied() in case of failure due to interruption
of internal operations in the current Galera implementation.

3) Some mtr test sometimes fails when node is evicted from
the cluster in middle of SST.

Even when node evicted, the SST script may completes normally.
After this, the node calls the gcs_join() function and tries
to join the cluster. However, this is impossible, because the
node is already evicted. Therefore, the _join() function
(which called from gcs_join) fails. Then node does IST
(which also fails), after/during which it is aborted.

To fix this, we should avoid joining the cluster through
gcs_join function if node is evicted. To do this, we should
check the current connection state in the gcs_join() function
to return from it immediately if the node's communication
channel was closed.

4) If SST fails due to a network error, the node that acted
as a donor sometimes does not return to its original state,
which leads to failure due to the inability to continue
the test execution (due to a timeout).

If sst_sent() fails node should restore itself back to joined
state. The sst_sent function can fail. commonly due to network
errors, where DONOR may lose connectivity to JOINER (or existing
cluster). But on re-join it should restore the original state
without waiting for transition to JOINER state. SST failure
on JOINER will gracefully shutdown the joiner.

https://jira.mariadb.org/browse/MDEV-17565