### PR TITLE
Debian build - requires dpkg-buildpackage

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,7 +103,7 @@ elif [ "$OS" == "FreeBSD" ]; then
   EXTRA_SYSROOT=/usr/local
 fi
 
-which dpkg >/dev/null 2>&1 && DEBIAN=${DEBIAN:-1} || DEBIAN=${DEBIAN:-0}
+which dpkg-buildpackage >/dev/null 2>&1 && DEBIAN=${DEBIAN:-1} || DEBIAN=${DEBIAN:-0}
 
 if [ "$OS" == "FreeBSD" ]; then
     CC=${CC:-"clang"}


### PR DESCRIPTION
From https://buildbot.mariadb.org/#/builders/311/builds/18147, its possible to have a container build without dpkg.

What is required is dpkg-buildpackage and we can use that to auto-populate DEBIAN=1