### PR TITLE
sles/opensuse 15 dependency on ssl-devel

### DIFF
--- a/scripts/packages/galera.spec
+++ b/scripts/packages/galera.spec
@@ -51,7 +51,15 @@ BuildRoot:     %{_tmppath}/%{name}-%{version}
 #BuildRequires: boost-devel
 #BuildRequires: check-devel
 BuildRequires: glibc-devel
+%if "%{dist}" == ".opensuse-leap15"
+BuildRequires: pkgconfig(libssl)
+%else
+%if "%{dist}" == ".sle15"
+BuildRequires: pkgconfig(libssl)
+%else
 BuildRequires: openssl-devel
+%endif
+%endif
 
 %if 0%{?suse_version} == 1110
 # On SLES11 SPx use the linked gcc47 to build instead of default gcc43


### PR DESCRIPTION
The common bits of rpm -qi --provides for:
* libopenssl-devel
* libopenssl-3-devel
* libopenssl-1_1-devel

are:

pkgconfig(libcrypto)
pkgconfig(libopenssl)
pkgconfig(libssl)
pkgconfig(openssl)

Libssl seems the most accurate on usage.