### PR TITLE
build: empty /etc/os-release

### DIFF
--- a/scripts/packages/rpm.sh
+++ b/scripts/packages/rpm.sh
@@ -60,7 +60,8 @@ fi
 # from /etc/os-release
 if  [ -z "$DIST_TAG" ]
 then
-  DIST_TAG=".${ID}${VERSION_ID%%.*}"
+  VERSION_ID=${VERSION_ID:-}
+  DIST_TAG=".${ID:-unknown}${VERSION_ID%%.*}"
 fi
 
 $(which rpmbuild) --clean --define "_topdir $RPM_TOP_DIR" \


### PR DESCRIPTION
Without a /etc/os-release ID and VERSION_ID would be blank, so lets just populate these with an unknown tag.