### PR TITLE
macos: fix gu_cond usage for darwin after 09848b6

### DIFF
--- a/galerautils/src/gu_threads.c
+++ b/galerautils/src/gu_threads.c
@@ -248,11 +248,11 @@ int gu_barrier_init_SYS (gu_barrier_t_SYS *barrier,
         errno = EINVAL;
         return -1;
     }
-    if(gu_mutex_init_SYS (&barrier->mutex, 0) < 0)
+    if(gu_mutex_init_SYS (NULL, &barrier->mutex) < 0)
     {
         return -1;
     }
-    if(gu_cond_init_SYS (&barrier->cond, 0) < 0)
+    if(gu_cond_init_SYS (NULL, &barrier->cond) < 0)
     {
         gu_mutex_destroy_SYS (&barrier->mutex);
         return -1;
@@ -279,13 +279,13 @@ int gu_barrier_wait_SYS (gu_barrier_t_SYS *barrier)
         barrier->count = 0;
         gu_cond_broadcast_SYS (&barrier->cond);
         gu_mutex_unlock_SYS (&barrier->mutex);
-        return GU_BARRIER_THREAD_SYS;
+        return GU_BARRIER_SERIAL_THREAD_SYS;
     }
     else
     {
         gu_cond_wait_SYS (&barrier->cond, &(barrier->mutex));
         gu_mutex_unlock_SYS (&barrier->mutex);
-        return !GU_BARRIER_THREAD_SYS;
+        return !GU_BARRIER_SERIAL_THREAD_SYS;
     }
 }
 

--- a/galerautils/src/gu_threads.h
+++ b/galerautils/src/gu_threads.h
@@ -11,7 +11,7 @@
 
 #include "gu_types.h" // bool
 
-#if __unix__
+#if defined(__unix__) || defined(__APPLE__)
 
 #include <pthread.h>
 #include <assert.h>
@@ -318,7 +318,7 @@ typedef pthread_barrier_t      gu_barrier_t_SYS;
 
 #endif /* native POSIX barriers */
 
-#endif /* __unix__ */
+#endif /* defined(__unix__) || defined(__APPLE__) */
 
 /**
  *  Depending on compile-time flags application will either use


### PR DESCRIPTION
macos: fix gu_cond usage for darwin after 09848b6

the patch 09848b6 by Jan from 2021-11-11 14:22:24 +0200 that swapped the
order of the arguments to gu_mutex_init_SYS. so now its
`gu_mutex_init_SYS(const wsrep_mutex_key_t* key, gu_mutex_t_SYS *mutex)`
so that for keyless mutexes its using (NULL, &mutex).

considering GU_BARRIER_THREAD_SYS replacement:

it was introduced by dabe053 8 years ago, but I suppose it never
compiled as at that moment there were no GU_BARRIER_THREAD_SYS.

it is synonymous to PTHREAD_BARRIER_SERIAL_THREAD that is must return
something non-usual on success (here its -1) for a thread synced with a
barrier as per POSIX https://linux.die.net/man/3/pthread_barrier_wait

> The constant PTHREAD_BARRIER_SERIAL_THREAD is defined in
<[pthread.h](https://linux.die.net/include/pthread.h)> and its value
shall be distinct from any other value returned by
pthread_barrier_wait().

> Upon successful completion, the pthread_barrier_wait() function shall
return PTHREAD_BARRIER_SERIAL_THREAD for a single (arbitrary) thread
synchronized at the barrier and zero for each of the other threads.

there is no such a constant in the code GU_BARRIER_THREAD_SYS.

follow up https://github.com/MariaDB/galera/pull/20
CI https://buildbot.mariadb.org/#/grid?branch=refs%2Fpull%2F25%2Fmerge