### PR TITLE
Fix complulation on BB

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -113,12 +113,6 @@ else
     CXX=${CXX:-"g++"}
 fi
 
-if ccache -V > /dev/null 2>&1
-then
-    echo "$CC"  | grep "ccache" > /dev/null || CC="ccache $CC"
-    echo "$CXX" | grep "ccache" > /dev/null || CXX="ccache $CXX"
-fi
-
 # MariaDB Centos5 & SLES-SP1 buildbot images require LD_LIBRARY_PATH to
 # /usr/local/lib
 if [ -r /etc/redhat-release ]; then

--- a/scripts/packages/galera.spec
+++ b/scripts/packages/galera.spec
@@ -60,10 +60,10 @@ BuildRequires: openssl-devel
 %endif
 %endif
 
-%if 0%{?rhel} == 8
-BuildRequires: python3-scons
+%if 0%{?rhel} == 7
+BuildRequires: cmake3
 %else
-BuildRequires: scons
+BuildRequires: cmake
 %endif
 
 %if 0%{?suse_version} == 1110


### PR DESCRIPTION
Recent changes made quite a mess of the build.

https://buildbot.mariadb.org/#/grid?branch=mariadb-4.x

Debian changes resulting in "ccache g++" being treated as a literal compiler.

This is from https://github.com/MariaDB/galera/commit/ff1dcf9475e1a209a9b97ba263fd3691e09ef315#diff-3d64996115d0ac3b74e36f57ce6b00d6b4982614c41b1ed39eab8ef43b2e9a2bR116

I've removed the ccache as this is just a very quick thing thing to build anyway.

RPM Builds where failing because of the scons build dependency, that wasn't used. I replaced this with cmake, and cmake3 for the backport on RHEL7.

https://buildbot.mariadb.org/#/grid?branch=refs%2Fpull%2F26%2Fmerge for resulting changes.