### PR TITLE
remove template-id-dtor warning in gcc-14.2.1

### DIFF
--- a/galerautils/src/gu_atomic.hpp
+++ b/galerautils/src/gu_atomic.hpp
@@ -19,7 +19,7 @@ namespace gu
     class Atomic
     {
     public:
-        Atomic<I>(I i = 0) : i_(i) { }
+        explicit Atomic(I i = 0) : i_(i) { }
 
         I operator()() const
         {


### PR DESCRIPTION
The warning was:

/galerautils/src/gu_atomic.hpp:22:19: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   22 |         Atomic<I>(I i = 0) : i_(i) { }
      |                   ^
galerautils/src/gu_atomic.hpp:22:19: note: remove the ‘< >’

As the template is I, it doesn't need to be specified.

Also needs to be made explicit to remove this error:

Class 'Atomic' has a constructor with 1 argument that is not explicit.