### PR TITLE
MDEV-35045: compile error with deprecated openssl/engine.h

### DIFF
--- a/cmake/asio.cmake
+++ b/cmake/asio.cmake
@@ -40,4 +40,9 @@ if(NOT ASIO_VERSION_OK)
   include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/asio)
 endif()
 
+check_include_file_cxx(openssl/engine.h HAVE_ENGINE_H)
+if(NOT HAVE_ENGINE_H)
+  add_definitions(-DOPENSSL_NO_ENGINE)
+endif()
+
 add_definitions(-DHAVE_ASIO_HPP)

--- a/galerautils/tests/gu_asio_test.cpp
+++ b/galerautils/tests/gu_asio_test.cpp
@@ -1059,7 +1059,7 @@ END_TEST
 
 #include <openssl/bn.h>
 #include <openssl/conf.h>
-#include <openssl/engine.h>
+#include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>


### PR DESCRIPTION
Fedora (41) is deprecating the Openssl engine[1]. The bundled asio has defines around OPENSSL_NO_ENGINE, but never checks or sets this.

This adds a check for the openssl/engine.h which might be included via the openssl-devel-engine package.

Also teh gu_asio_test.cpp needs the err.h header and not the engine one for the ERR_get_error function.

[1]: https://fedoraproject.org/wiki/Changes/OpensslDeprecateEngine