### PR TITLE
std::mem_fun and std::bind2nd are deprecated

### DIFF
--- a/galerautils/tests/gu_net_test.cpp
+++ b/galerautils/tests/gu_net_test.cpp
@@ -20,7 +20,7 @@
 using std::vector;
 using std::string;
 using std::deque;
-using std::mem_fun;
+using std::mem_fn;
 using std::for_each;
 using namespace gu;
 using namespace gu::net;

--- a/gcomm/test/check_trace.hpp
+++ b/gcomm/test/check_trace.hpp
@@ -303,8 +303,10 @@ namespace gcomm
         void connect(bool first)
         {
             gu_trace(std::for_each(protos_.rbegin(), protos_.rend(),
-                                   std::bind2nd(
-                                       std::mem_fun(&Protolay::connect), first)));
+                                   std::bind(
+                                       std::mem_fn(&Protolay::connect),
+				           std::placeholders::_1,
+					   first)));
         }
 
         void close(bool force = false)
@@ -315,7 +317,7 @@ namespace gcomm
                 (*i)->close();
             }
             // gu_trace(std::for_each(protos.rbegin(), protos.rend(),
-            //                       std::mem_fun(&Protolay::close)));
+            //                       std::mem_fn(&Protolay::close)));
         }
 
 
@@ -327,7 +329,7 @@ namespace gcomm
                 (*i)->close(uuid);
             }
             // gu_trace(std::for_each(protos.rbegin(), protos.rend(),
-            //                       std::mem_fun(&Protolay::close)));
+            //                       std::mem_fn(&Protolay::close)));
         }
 
         void send()
@@ -420,7 +422,7 @@ namespace gcomm
         gu::datetime::Date handle_timers()
         {
             std::for_each(protos_.begin(), protos_.end(),
-                          std::mem_fun(&Protolay::handle_timers));
+                          std::mem_fn(&Protolay::handle_timers));
             return gu::datetime::Date::max();
         }
 


### PR DESCRIPTION
mem_fun -> mem_fn is a straight replacement.

bind2nd required and additional argument in
the transition to std::bind