### PR TITLE
Make Galera work with OpenZFS >= 2.3.0

### DIFF
--- a/galerautils/src/gu_fdesc.cpp
+++ b/galerautils/src/gu_fdesc.cpp
@@ -244,7 +244,7 @@ namespace gu
         {
             errno = ret;
 #endif
-            if ((EINVAL == errno || ENOSYS == errno) && start >= 0 && diff > 0)
+            if ((EINVAL == errno || ENOSYS == errno || EOPNOTSUPP == errno) && start >= 0 && diff > 0)
             {
                 // FS does not support the operation, try physical write
                 write_file (start);


### PR DESCRIPTION
In https://github.com/openzfs/zfs/pull/16918 OpenZFS was made to return ENOTSUPP instead of EINVAL when trying to use posix_fallocate() on a ZFS filesystem, handle that in Galera otherwise the server stops with the following error message:

[ERROR] WSREP: File preallocation failed: System error: 45 (Operation not supported)
        at /wrkdirs/usr/ports/databases/galera26/work/galera-mariadb-26.4.21/galerautils/src/gu_fdesc.cpp:prealloc():254
[ERROR] WSREP: Failed to create a new provider '/usr/local/lib/libgalera_smm.so' with options '': Failed to initialize wsrep provider [ERROR] WSREP: Failed to load provider
[ERROR] Aborting