### PR TITLE
MDEV-35108 galera rpm build error in Fedora 41

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -2,6 +2,11 @@
 # Copyright (C) 2025 Codership Oy <info@codership.com>
 #
 
+# For compatibility with old platforms, use FindBoost.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
+  cmake_policy(SET CMP0167 OLD)
+endif()
+
 set(Boost_USE_MULTITHREAD ON)
 set(Boost_USE_STATIC_LIBS ${GALERA_STATIC})
 find_package(Boost 1.41 COMPONENTS filesystem program_options system)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -393,7 +393,7 @@ build_sources()
 GALERA_VER=$RELEASE
 
 pushd "$build_base"
-GALERA_REV=$(git log --pretty=format:'%h' -n1.) || \
+GALERA_REV=$(git log --pretty=format:'%h' -n1) || \
 GALERA_REV="XXXXX"
 # trim spaces (sed is not working on Solaris, so using bash built-in)
 GALERA_REV=${GALERA_REV//[[:space:]]/}
@@ -404,9 +404,9 @@ then
     source GALERA_VERSION
     RELEASE="$GALERA_VERSION_WSREP_API.$GALERA_VERSION_MAJOR.$GALERA_VERSION_MINOR"
 fi
-if [ "$PACKAGE" == "yes" -a $DEBIAN -ne 0 ]
+if [ "$PACKAGE" == "yes" -a "$OS" == "Linux" ]
 then
-    echo "Debian package build"
+    echo "Debian or RPM package build"
 elif [ "$CMAKE" == "yes" ] # Build using CMake
 then
     cmake_args="$CMAKE_OPTS -DGALERA_REVISION=$GALERA_REV"

--- a/scripts/packages/galera-4.spec
+++ b/scripts/packages/galera-4.spec
@@ -40,16 +40,21 @@ Group:         System Environment/Libraries
 Version:       %{version}
 Release:       %{release}%{dist}
 License:       GPL-2.0
-Source:        http://www.codership.com/downloads/download-mysqlgalera/
+Source:        %{name}-%{version}.tar.gz
 URL:           http://www.codership.com/
 Packager:      Codership Oy
 Vendor:        Codership Oy
 
-BuildRoot:     %{_tmppath}/%{name}-%{version}
-
-#BuildRequires: boost-devel
-#BuildRequires: check-devel
+%if 0%{?suse_version} >= 1500
+BuildRequires: (libboost_filesystem1_66_0-devel or libboost_filesystem1_75_0-devel)
+BuildRequires: (libboost_program_options1_66_0-devel or libboost_program_options1_75_0-devel)
+BuildRequires: (libboost_system1_66_0-devel or libboost_system1_75_0-devel)
+%else
+BuildRequires: boost-devel
+%endif
+BuildRequires: check-devel
 BuildRequires: glibc-devel
+BuildRequires: pkgconfig
 %if "%{dist}" == ".opensuse-leap15"
 BuildRequires: pkgconfig(libssl)
 %else
@@ -119,18 +124,36 @@ This software comes with ABSOLUTELY NO WARRANTY. This is free software,
 and you are welcome to modify and redistribute it under the GPLv2 license.
 
 %prep
-#%setup -T -a 0 -c -n galera-%{version}
+%setup -q
+
+# Note: We don't use cmake macros as they don't provide uniform
+# bahavior on all platforms in Buildbot. Instead, define cmake_exe
+# and ctest_exe based on platform (RHEL7 is the only one left with cmake3)
+# and work directly on those.
+%if 0%{?rhel} == 7
+%define cmake_exe cmake3
+%define ctest_exe ctest3
+%else
+%define cmake_exe cmake
+%define ctest_exe ctest
+%endif
 
 %build
-Build() {
-CFLAGS=${CFLAGS:-$RPM_OPT_FLAGS}
-CXXFLAGS=${CXXFLAGS:-$RPM_OPT_FLAGS}
-# We assume that Galera is built already by the top build.sh script
-}
+%cmake_exe -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+           -DCMAKE_INSTALL_DO_STRIP:BOOL=OFF
+%cmake_exe --build build %_smp_mflags
+
+%check
+%ctest_exe --output-on-failure --force-new-ctest-process \
+           --timeout 120 --test-dir build
 
 %install
-RBR=$RPM_BUILD_ROOT
-RBD=$RPM_BUILD_DIR
+RBR=%{buildroot}
+# Install step is executed in build dir
+RBD=.
+# CMake build directory
+CBD=build
 
 # Clean up the BuildRoot first
 [ "$RBR" != "/" ] && [ -d $RBR ] && rm -rf $RBR;
@@ -159,10 +182,10 @@ install -m 644 $RBD/garb/files/garb.cnf $RBR%{_sysconfdir}/sysconfig/garb
 %endif
 
 install -d $RBR%{_bindir}
-install -m 755 $RBD/garb/garbd                    $RBR%{_bindir}/garbd
+install -m 755 $CBD/garb/garbd                    $RBR%{_bindir}/garbd
 
 install -d $RBR%{libs}
-install -m 755 $RBD/libgalera_smm.so              $RBR%{libs}/libgalera_smm.so
+install -m 755 $CBD/libgalera_smm.so              $RBR%{libs}/libgalera_smm.so
 
 install -d $RBR%{docs}
 install -m 644 $RBD/COPYING                       $RBR%{docs}/COPYING

--- a/scripts/packages/rpm.sh
+++ b/scripts/packages/rpm.sh
@@ -14,14 +14,21 @@ THIS_DIR=$(pwd -P)
 
 RPM_TOP_DIR=$SCRIPT_ROOT/rpm_top_dir
 rm -rf $RPM_TOP_DIR
-mkdir -p $RPM_TOP_DIR/RPMS
-ln -s ../../../ $RPM_TOP_DIR/BUILD
+mkdir -p $RPM_TOP_DIR/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+PROJECT_ROOT=$(cd $SCRIPT_ROOT/../..; pwd -P)
+CMAKE_BUILD_DIR=$RPM_TOP_DIR/cmake_build
+mkdir -p $CMAKE_BUILD_DIR
+
+pushd $CMAKE_BUILD_DIR > /dev/null
+# Generate CPack config
+cmake $PROJECT_ROOT
+# Create source package with the specified version
+cpack --config CPackSourceConfig.cmake -D CPACK_PACKAGE_VERSION=$1 -G TGZ
+mv galera-4-$1.tar.gz $RPM_TOP_DIR/SOURCES/
+popd > /dev/null
+
 export CK_TIMEOUT_MULTIPLIER=5
 
-fast_cflags="-O3 -fno-omit-frame-pointer"
-uname -m | grep -q i686 && \
-cpu_cflags="-mtune=i686" || cpu_cflags="-mtune=core2"
-RPM_OPT_FLAGS="$fast_cflags $cpu_cflags"
 GALERA_SPEC=$SCRIPT_ROOT/galera-4.spec
 
 RELEASE=${RELEASE:-"1"}
@@ -62,14 +69,11 @@ then
   DIST_TAG=".${ID:-unknown}${VERSION_ID%%.*}"
 fi
 
-# no cmake3 installed? Pretend the build dependency is cmake
-rpm -q cmake3 || sed -i -e 's/cmake3/cmake/' "$GALERA_SPEC"
-
 rpmbuild --clean --define "_topdir $RPM_TOP_DIR" \
-                  --define "optflags $RPM_OPT_FLAGS" \
                   --define "version $1" \
                   --define "dist ${DIST_TAG}" \
-                  -bb $GALERA_SPEC
+                  ${JOBS:+--define "_smp_mflags -j$JOBS"} \
+                  -bb $GALERA_SPEC || (rpm --showrc && exit 1)
 
 RPM_ARCH=$(rpm --showrc | grep "^build arch" | awk '{print $4}')
 


### PR DESCRIPTION
The workflow of Galera RPM build through scripts/build.sh -p
was non-standard and problematic. The compilation happened
outside of spec file, and rpmbuild/spec was used only for
packaging the build results.

In order to have more portable approach, change to more
standard RPM build approach:

- scripts/build.sh - Skip cmake/compilation if building DEB/RPM
  packages
- scripts/packages/rpm.sh - Initialize directory hierarchy for
  rpmbuild and prepare source package
- scripts/packages/galera-4.spec - run cmake config step
  with RelWithDebInfo build type, compile in `%build` stage, and
  run unit tests in `%check` stage
- scripts/packages/galera-4.spec - Fix RBD path initialization,
  the `%install` stage is always executed in build dir

Other fixes:
- cmake/boost.cmake - Set policy CMP0167 to avoid FindBoost warning
- scripts/build.sh - Remove extra dot in git log args
- scripts/packages/rpm.sh - Remove optflags from rpmbuild arguments
  (who needs `-mtune=i686` or `-mtune=core2` anymore?)
- scripts/packages/rpm.sh - Respect JOBS environment variable, pass
  in `_smp_mflags` to rpmbuild if defined
- Adjust SUSE build dependencies according to packages installed
  in buildbot
- scripts/packages/rpm.sh Print all rpmbuild macros on failure for
  troubleshooting