### PR TITLE
Tranform the logging scheme to use wsrep_api types/constants

### DIFF
--- a/galerautils/src/gu_log.c
+++ b/galerautils/src/gu_log.c
@@ -19,7 +19,7 @@
 /* Global configurable variables */
 static FILE*      gu_log_file        = NULL;
 bool              gu_log_self_tstamp = false;
-gu_log_severity_t gu_log_max_level   = GU_LOG_INFO;
+wsrep_log_level_t gu_log_max_level = WSREP_LOG_INFO;
 
 int
 gu_conf_set_log_file (FILE *file)
@@ -54,7 +54,7 @@ gu_conf_self_tstamp_off ()
 int
 gu_conf_debug_on ()
 {
-    gu_log_max_level = GU_LOG_DEBUG;
+    gu_log_max_level = WSREP_LOG_DEBUG;
     gu_debug ("Turning debug logging on");
     return 0;
 }
@@ -63,7 +63,7 @@ int
 gu_conf_debug_off ()
 {
     gu_debug ("Turning debug logging off");
-    gu_log_max_level = GU_LOG_INFO;
+    gu_log_max_level = WSREP_LOG_INFO;
     return 0;
 }
 
@@ -86,7 +86,7 @@ log_tstamp (char* tstamp, size_t const len)
     return ret;
 }
 
-const char* gu_log_level_str[GU_LOG_DEBUG + 2] = 
+const char* gu_log_level_str[WSREP_LOG_DEBUG + 2] =
 {
     "FATAL: ",
     "ERROR: ",
@@ -101,7 +101,7 @@ const char* gu_log_level_str[GU_LOG_DEBUG + 2] =
  * Default logging function: simply writes to stderr or gu_log_file if set.
  */
 void
-gu_log_cb_default (int severity, const char* msg)
+gu_log_cb_default (wsrep_log_level_t severity, const char* msg)
 {
     FILE* log_file = gu_log_file ? gu_log_file : stderr;
     fputs  (msg,  log_file);
@@ -129,7 +129,7 @@ gu_conf_set_log_callback (gu_log_cb_t callback)
 }
 
 int
-gu_log (gu_log_severity_t severity,
+gu_log (wsrep_log_level_t severity,
         const char*       file,
         const char*       function,
         const int         line,
@@ -154,7 +154,7 @@ gu_log (gu_log_severity_t severity,
             gu_log_cb_default == gu_log_cb ? gu_log_level_str[severity] : "";
 
         /* provide file:func():line info only if debug logging is on */
-        if (gu_likely(!gu_log_debug && severity > GU_LOG_ERROR)) {
+        if (gu_likely(!gu_log_debug && severity > WSREP_LOG_ERROR)) {
             len = snprintf (str, max_string, "%s", log_level_str);
         }
         else {

--- a/galerautils/src/gu_log.h
+++ b/galerautils/src/gu_log.h
@@ -11,6 +11,7 @@
 
 #include "gu_macros.h"
 #include <stdlib.h> /* For NULL */
+#include "wsrep_api.h"
 
 #if defined(__cplusplus)
 extern "C"
@@ -31,26 +32,17 @@ extern "C"
  * debug - debugging message.
  */
 
-typedef enum gu_log_severity
-{
-    GU_LOG_FATAL,
-    GU_LOG_ERROR,
-    GU_LOG_WARN,
-    GU_LOG_INFO,
-    GU_LOG_DEBUG
-}
-gu_log_severity_t;
 
 /**
  * @typedef
  * Defines a type of callback function that application can provide
  * to do the logging
  */
-typedef void (*gu_log_cb_t) (int severity, const char* msg);
+typedef void (*gu_log_cb_t) (wsrep_log_level_t, const char* msg);
 
 /** Helper for macros defined below. Should not be called directly. */
 extern int
-gu_log (gu_log_severity_t severity,
+gu_log (wsrep_log_level_t severity,
         const char*       file,
         const char*       function,
         const int         line,
@@ -60,9 +52,9 @@ gu_log (gu_log_severity_t severity,
 /** This variable is made global only for the purpose of using it in
  *  gu_debug() macro and avoid calling gu_log() when debug is off.
  *  Don't use it directly! */
-extern gu_log_severity_t gu_log_max_level;
+extern wsrep_log_level_t gu_log_max_level;
 
-#define gu_log_debug (GU_LOG_DEBUG == gu_log_max_level)
+#define gu_log_debug (WSREP_LOG_DEBUG == gu_log_max_level)
 
 #if defined(__cplusplus)
 }
@@ -76,17 +68,17 @@ extern gu_log_severity_t gu_log_max_level;
  */
 /*@{*/
 #define gu_fatal(...)                                                          \
-    gu_log(GU_LOG_FATAL, __FILE__, __func__, __LINE__, __VA_ARGS__);
+    gu_log(WSREP_LOG_FATAL, __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define gu_error(...)                                                          \
-    gu_log(GU_LOG_ERROR, __FILE__, __func__, __LINE__, __VA_ARGS__);
+    gu_log(WSREP_LOG_ERROR, __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define gu_warn(...)                                                           \
-    gu_log(GU_LOG_WARN, __FILE__, __func__, __LINE__, __VA_ARGS__);
+    gu_log(WSREP_LOG_WARN, __FILE__, __func__, __LINE__, __VA_ARGS__);
 #define gu_info(...)                                                           \
-    gu_log(GU_LOG_INFO, __FILE__, __func__, __LINE__, __VA_ARGS__)
+    gu_log(WSREP_LOG_INFO, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define gu_debug(...)                                                          \
     if (gu_unlikely(gu_log_debug))                                             \
     {                                                                          \
-        gu_log(GU_LOG_DEBUG, __FILE__, __func__, __LINE__, __VA_ARGS__);       \
+        gu_log(WSREP_LOG_DEBUG, __FILE__, __func__, __LINE__, __VA_ARGS__);       \
     }
 /*@}*/
 
@@ -100,7 +92,7 @@ extern "C"
 {
 extern bool        gu_log_self_tstamp;
 extern gu_log_cb_t gu_log_cb;
-extern void        gu_log_cb_default (int, const char*);
+extern void        gu_log_cb_default (wsrep_log_level_t, const char*);
 extern const char* gu_log_level_str[];
 }
 #endif /* _gu_log_extra_ */

--- a/galerautils/src/gu_logger.cpp
+++ b/galerautils/src/gu_logger.cpp
@@ -75,58 +75,8 @@ namespace gu
         return debug_filter.size() > 0 && debug_filter.is_set(func) == false;
     }
 
-#ifndef _gu_log_h_
-    void
-    Logger::enable_tstamp (bool yes)
-    {
-        do_timestamp = yes;
-    }
-
-    void
-    Logger::enable_debug (bool yes)
-    {
-        if (yes) {
-            max_level = LOG_DEBUG;
-        }
-        else {
-            max_level = LOG_INFO;
-        }
-    }
-
-    void
-    Logger::default_logger (int lvl, const char* msg)
-    {
-        fputs  (msg, stderr); fputc ('\n', stderr);
-        fflush (stderr);
-    }
-
-    void
-    Logger::set_logger (LogCallback cb)
-    {
-        if (0 == cb) {
-            logger = default_logger;
-        }
-        else {
-            logger = cb;
-        }
-    }
-
-    static const char* level_str[LOG_MAX] = 
-    {
-        "FATAL: ",
-        "ERROR: ",
-        " WARN: ",
-        " INFO: ",
-        "DEBUG: "
-    };
-
-    bool        Logger::do_timestamp = false;
-    LogLevel    Logger::max_level    = LOG_INFO;
-    LogCallback Logger::logger       = default_logger;
-#else
 #define do_timestamp       gu_log_self_tstamp == true
 #define level_str          gu_log_level_str
-#endif // _gu_log_h_
 
     void
     Logger::prepare_default()

--- a/galerautils/src/gu_logger.hpp
+++ b/galerautils/src/gu_logger.hpp
@@ -16,28 +16,19 @@
 extern "C" {
 #include "gu_log.h"
 #include "gu_conf.h"
+#include "wsrep_api.h" // wsrep_log_level_t
 }
 
 namespace gu
 {
     // some portability stuff
-#ifdef _gu_log_h_
-    enum LogLevel { LOG_FATAL = GU_LOG_FATAL,
-                    LOG_ERROR = GU_LOG_ERROR,
-                    LOG_WARN  = GU_LOG_WARN,
-                    LOG_INFO  = GU_LOG_INFO,
-                    LOG_DEBUG = GU_LOG_DEBUG,
+    enum LogLevel { LOG_FATAL = WSREP_LOG_FATAL,
+                    LOG_ERROR = WSREP_LOG_ERROR,
+                    LOG_WARN  = WSREP_LOG_WARN,
+                    LOG_INFO  = WSREP_LOG_INFO,
+                    LOG_DEBUG = WSREP_LOG_DEBUG,
                     LOG_MAX };
     typedef gu_log_cb_t LogCallback;
-#else
-    enum LogLevel { LOG_FATAL,
-                    LOG_ERROR,
-                    LOG_WARN,
-                    LOG_INFO,
-                    LOG_DEBUG,
-                    LOG_MAX };
-    typedef void (*LogCallback) (int, const char*);
-#endif
 
     class Logger
     {
@@ -49,16 +40,9 @@ namespace gu
         void               prepare_default ();
         const LogLevel     level;
 
-#ifndef _gu_log_h_
-        static LogLevel    max_level;
-        static bool        do_timestamp;
-        static LogCallback logger;
-        static void        default_logger  (int, const char*);
-#else
 #define max_level          gu_log_max_level
 #define logger             gu_log_cb
 #define default_logger     gu_log_cb_default
-#endif
 
     protected:
 
@@ -71,7 +55,7 @@ namespace gu
             os     ()
         {}
 
-        virtual ~Logger() { logger (level, os.str().c_str()); }
+        virtual ~Logger() { logger ((wsrep_log_level_t) level, os.str().c_str()); }
 
         std::ostringstream& get(const char* file,
                                 const char* func,
@@ -100,11 +84,6 @@ namespace gu
 
         static bool no_debug(const std::string&, const std::string&, const int);
 
-#ifndef _gu_log_h_
-        static void enable_tstamp (bool);
-        static void enable_debug  (bool);
-        static void set_logger    (LogCallback);
-#endif
     };
 
 #define GU_LOG_CPP(level)                                               \

--- a/garb/garb_logger.cpp
+++ b/garb/garb_logger.cpp
@@ -4,6 +4,7 @@
 
 #include <gu_throw.hpp>
 #include <gu_conf.h>
+#include "gu_log.h"
 
 #include <cstdio>
 
@@ -24,17 +25,17 @@ namespace garb
         gu_conf_set_log_file (log_file);
     }
 
-    static void log_to_syslog (int level, const char* msg)
+    static void log_to_syslog (wsrep_log_level_t level, const char* msg)
     {
         int p = LOG_NOTICE;
 
         switch (level)
         {
-        case GU_LOG_FATAL: p = LOG_CRIT;    break;
-        case GU_LOG_ERROR: p = LOG_ERR;     break;
-        case GU_LOG_WARN:  p = LOG_WARNING; break;
-        case GU_LOG_INFO:  p = LOG_INFO;    break;
-        case GU_LOG_DEBUG: p = LOG_DEBUG;   break;
+        case WSREP_LOG_FATAL: p = LOG_CRIT;    break;
+        case WSREP_LOG_ERROR: p = LOG_ERR;     break;
+        case WSREP_LOG_WARN:  p = LOG_WARNING; break;
+        case WSREP_LOG_INFO:  p = LOG_INFO;    break;
+        case WSREP_LOG_DEBUG: p = LOG_DEBUG;   break;
         }
 
         syslog (p | LOG_DAEMON, "%s", msg);

--- a/gcomm/test/check_evs2.cpp
+++ b/gcomm/test/check_evs2.cpp
@@ -2317,7 +2317,7 @@ START_TEST(test_gap_rate_limit)
     // Start time from 1 sec to avoid hitting gap rate limit for the first
     // gap message.
     gu::datetime::SimClock::init(gu::datetime::Sec);
-    gu_log_max_level = GU_LOG_DEBUG;
+    gu_log_max_level = WSREP_LOG_DEBUG;
     TwoNodeFixture f;
     gcomm::Protolay::sync_param_cb_t spcb;
 
@@ -2409,7 +2409,7 @@ START_TEST(test_gap_rate_limit_delayed)
     // Start time from 1 sec to avoid hitting gap rate limit for the first
     // gap message.
     gu::datetime::SimClock::init(gu::datetime::Sec);
-    gu_log_max_level = GU_LOG_DEBUG;
+    gu_log_max_level = WSREP_LOG_DEBUG;
     TwoNodeFixture f;
     gcomm::Protolay::sync_param_cb_t spcb;
 

--- a/gcomm/test/check_gcomm.cpp
+++ b/gcomm/test/check_gcomm.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
 
     if (::getenv("CHECK_GCOMM_DEBUG"))
     {
-        gu_log_max_level = GU_LOG_DEBUG;
+        gu_log_max_level = WSREP_LOG_DEBUG;
         //gu::Logger::enable_debug(true);
     }
 

--- a/gcomm/test/check_gcomm_nondet.cpp
+++ b/gcomm/test/check_gcomm_nondet.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 
     if (::getenv("CHECK_GCOMM_DEBUG"))
     {
-        gu_log_max_level = GU_LOG_DEBUG;
+        gu_log_max_level = WSREP_LOG_DEBUG;
         //gu::Logger::enable_debug(true);
     }
 

--- a/gcomm/test/check_gmcast.cpp
+++ b/gcomm/test/check_gmcast.cpp
@@ -420,7 +420,7 @@ START_TEST(test_gmcast_ipv6)
     gu::ssl_register_params(conf);
     gcomm::Conf::register_params(conf);
     conf.set("base_host", "ip6-localhost");
-    gu_log_max_level = GU_LOG_DEBUG;
+    gu_log_max_level = WSREP_LOG_DEBUG;
     std::unique_ptr<gcomm::Protonet> pnet(gcomm::Protonet::create(conf));
 
     // Without scheme

--- a/gcomm/test/check_pc.cpp
+++ b/gcomm/test/check_pc.cpp
@@ -3614,7 +3614,7 @@ public:
 // * It is expected that the n1 ends up in non-primary component.
 START_TEST(test_quorum_2_to_2_in_3_node_cluster)
 {
-    gu_log_max_level = GU_LOG_DEBUG;
+    gu_log_max_level = WSREP_LOG_DEBUG;
     gcomm::pc::ProtoBuilder builder;
     gu::Config conf;
     gu::ssl_register_params(conf);

--- a/gcs/src/gcs_conf.cpp
+++ b/gcs/src/gcs_conf.cpp
@@ -8,10 +8,11 @@
 #include <galerautils.h>
 
 #include "gcs.hpp"
+#include "wsrep_api.h"
 
 long gcs_conf_set_log_file     (FILE *file)
 { return gu_conf_set_log_file (file); }
-long gcs_conf_set_log_callback (void (*logger) (int, const char*))
+long gcs_conf_set_log_callback (void (*logger) (wsrep_log_level_t, const char*))
 { return gu_conf_set_log_callback (logger); }
 long gcs_conf_self_tstamp_on   ()
 { return gu_conf_self_tstamp_on (); }


### PR DESCRIPTION
Running under UBSAN testing reported function-type-mismatch mismatches everywhere as this when through almost the same definition but enought to be detected as different.

Removed gu_log_severity_t and replaces with the wsrep_api.h provided wsrep_log_level_t.