### PR TITLE
UndefinedBehaviorSanitizer: misaligned-pointer-use mmh3

### DIFF
--- a/galerautils/src/gu_mmh3.c
+++ b/galerautils/src/gu_mmh3.c
@@ -163,7 +163,7 @@ _mmh3_128_blocks (const uint64_t* const blocks, size_t const nblocks,
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
         uint64_t k[2];
-        memcpy(k, &blocks[i], sizeof(k));
+        memcpy(k, (char *) &blocks[i], sizeof(k));
         _mmh3_128_block (gu_le64(k[0]), gu_le64(k[1]), h1, h2);
     }
 }
@@ -343,7 +343,7 @@ gu_mmh128_append (gu_mmh128_ctx_t* const mmh,
     _mmh3_128_blocks (blocks, nblocks, &mmh->hash[0], &mmh->hash[1]);
 
     /* save possible trailing bytes to tail */
-    memcpy (mmh->tail, blocks + nblocks, len & 15);
+    memcpy (mmh->tail, (char *) (blocks + nblocks), len & 15);
 }
 
 /*! Get the accumulated message hash (does not change the context) */


### PR DESCRIPTION
This is one way. The other is to perform aligned mallocs from the heap in the test cases.

Pointers not 8 byte aligned - error:

SUMMARY: UndefinedBehaviorSanitizer: misaligned-pointer-use /source/galerautils/src/gu_mmh3.c:166:19 /source/galerautils/src/gu_mmh3.c:166:19: runtime error: load of misaligned address 0x7b336d5015ec for type 'const uint64_t *' (aka 'const unsigned long *'), which requires 8 byte alignment 0x7b336d5015ec: note: pointer points here
  00 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00
              ^
    #0 0x560502c8e01b in _mmh3_128_blocks /source/galerautils/src/gu_mmh3.c:166:9
    #1 0x560502c8e01b in gu_mmh128_append /source/galerautils/src/gu_mmh3.c:343:5
    #2 0x560502aac548 in gu::MMH3::append(void const*, unsigned long) /source/galerautils/tests/../src/gu_digest.hpp:55:9
    #3 0x560502aac548 in gu::RecordSetOutBase::post_append(bool, unsigned char const*, long) /source/galerautils/tests/../src/gu_rset.hpp:276:16
    #4 0x560502aac548 in std::pair<unsigned char const*, unsigned long> gu::RecordSetOutBase::append_base<TestRecord, false>(TestRecord const&, bool, bool) /source/galerautils/tests/../src/gu_rset.hpp:225:9
    #5 0x560502aa4e18 in gu::RecordSetOut<TestRecord>::append(TestRecord const&) /source/galerautils/tests/../src/gu_rset.hpp:320:16
    #6 0x560502aa4e18 in test_version(gu::RecordSet::Version) /source/galerautils/tests/gu_rset_test.cpp:196:19
    #7 0x560502c88eea in srunner_run_tagged (/build/galerautils/tests/gu_tests+++0x447eea) (BuildId: 0a53558404f7636755fc927f95cb7683316089dc)
    #8 0x560502b6e630 in main /source/galerautils/tests/gu_tests++.cpp:36:9

and

SUMMARY: UndefinedBehaviorSanitizer: misaligned-pointer-use /source/galerautils/src/gu_mmh3.c:346:33 /source/galerautils/src/gu_mmh3.c:346:33: runtime error: load of misaligned address 0x5599159c1184 for type 'const uint64_t *' (aka 'const unsigned long *'), which requires 8 byte alignment 0x5599159c1184: note: pointer points here
  6b 65 79 32 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^
    #0 0x5599159877f5 in gu_mmh128_append /source/galerautils/src/gu_mmh3.c:346:5
    #1 0x559915410b66 in gu::MMH3::append(void const*, unsigned long) /source/galerautils/src/gu_digest.hpp:55:9
    #2 0x559915410b66 in galera::KeySetOut::KeyPart::KeyPart(galera::KeySetOut::KeyParts&, galera::KeySetOut&, galera::KeySetOut::KeyPart const*, galera::KeyData const&, int, int, int) /source/galera/src/key_set.cpp:243:11
    #3 0x55991541220d in galera::KeySetOut::append(galera::KeyData const&) /source/galera/src/key_set.cpp:405:21
    #4 0x55991538b12e in galera::WriteSetOut::append_key(galera::KeyData const&) /source/galera/src/write_set_ng.hpp:540:28
    #5 0x55991538b12e in galera::TrxHandleMaster::append_key(galera::KeyData const&) /source/galera/src/trx_handle.hpp:899:13
    #6 0x5599153d8f92 in store_trx(gcache::GCache*, gu::MemPool<true>&, galera::TrxHandleMaster::Params const&, wsrep_uuid const&, int) /source/galera/tests/ist_check.cpp:477:10
    #7 0x5599153d8f92 in test_ist_common(int, bool, bool) /source/galera/tests/ist_check.cpp:596:13
    #8 0x55991540c79a in srunner_run_tagged (/build/galera/tests/galera_check+0x59879a) (BuildId: 5fbd09886dfb3dc81665f233ab6b64376204b361)
    #9 0x55991535ce00 in main /source/galera/tests/galera_check.cpp:70:9