### PR TITLE
test: gu_str_test - UndefinedBehaviorSanitizer: function-type-mismatch

### DIFF
--- a/galerautils/tests/gu_str_test.c
+++ b/galerautils/tests/gu_str_test.c
@@ -109,7 +109,7 @@ START_TEST(test_str_table)
 END_TEST
 
 
-Suite* gu_str_suite()
+Suite* gu_str_suite(void)
 {
     Suite* s = suite_create("Galera Str util suite");
     TCase* tc;


### PR DESCRIPTION
Showed up under GALERA_WITH_UBSAN with clang-20.

/source/galerautils/tests/gu_tests.c:66:36: runtime error: call to function gu_str_suite through pointer to incorrect function type 'struct Suite *(*)(void)'
/source/galerautils/tests/gu_str_test.c:113: note: gu_str_suite defined here

SUMMARY: UndefinedBehaviorSanitizer: function-type-mismatch /source/galerautils/tests/gu_tests.c:66:36