### PR TITLE
Galera-4.spec - dist macro is .sle16 for openSUSE 16

### DIFF
--- a/scripts/packages/galera-4.spec
+++ b/scripts/packages/galera-4.spec
@@ -67,7 +67,11 @@ BuildRequires: pkgconfig(libssl)
 %if "%{dist}" == ".sle15"
 BuildRequires: pkgconfig(libssl)
 %else
+%if "%{dist}" == ".sle16"
+BuildRequires: pkgconfig(libssl)
+%else
 BuildRequires: openssl-devel
+%endif
 %endif
 %endif
 %endif


### PR DESCRIPTION
@janlindstrom Sorry, missed a bit on: https://github.com/MariaDB/galera/pull/48
got: https://buildbot.dev.mariadb.org/#/builders/783/builds/2/steps/3/logs/stdio

pkgconfig(ssl) - dist is overwritten to `.sle16" for opensuse

Tested this patch change:
https://buildbot.dev.mariadb.org/#/builders/783/builds/3