### PR TITLE
Fix the type flags for `EvsAutoEvict`

### DIFF
--- a/gcomm/src/defaults.hpp
+++ b/gcomm/src/defaults.hpp
@@ -125,7 +125,7 @@ namespace gcomm
         static const int EvsDelayedKeepPeriod = gu::Config::Flag::type_duration;
         static const int EvsEvict             = 0;
         static const int EvsAutoEvict         = gu::Config::Flag::read_only |
-                                                gu::Config::Flag::type_bool;
+                                                gu::Config::Flag::type_integer;
 
         static const int PcVersion            = gu::Config::Flag::read_only;
         static const int PcIgnoreSb           = gu::Config::Flag::type_bool;


### PR DESCRIPTION
The `evs.auto_evict` parameter is an integer that defines how many times a peer can be placed on the delayed list before the node votes to evict it.

Currently, `EvsAutoEvict` is flagged as a boolean, which prevents MariaDB from starting when `evs.auto_evict` is specified with a value greater than one. This commit fixes the type flags so that integers are accepted.

See [evs_proto.cpp#L4973](https://github.com/mariadb/galera/blob/c71ef30a8f9dec5146b93993a67059282a4268a0/gcomm/src/evs_proto.cpp#L4973) for where the value is used.