### PR TITLE
Added a fix when building with openssl4 by using the opaque

### DIFF
--- a/galerautils/tests/gu_asio_test.cpp
+++ b/galerautils/tests/gu_asio_test.cpp
@@ -1235,7 +1235,7 @@ static X509* create_x509(EVP_PKEY* pkey, X509* issuer, const char* cn,
     X509_gmtime_adj(X509_get_notAfter(x509), 31536000L);
     X509_set_pubkey(x509, pkey);
 
-    auto* name = X509_get_subject_name(x509);
+    X509_NAME* name = (X509_NAME*)X509_get_subject_name(x509);
     static const unsigned char C_str [] = "FI";
     static const unsigned char ST_str[] = "Uusimaa";
     static const unsigned char L_str [] = "Helsinki";


### PR DESCRIPTION
implementation of the X509_name_st struct as X509_NAME which was introduced in openssl-1.1.0 as can be seen here: https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes this means that the fix is applicable in openssl versions older than 4.0 as well and won't break anything